### PR TITLE
Use setTimeout if requestIdleCallback is unavailable

### DIFF
--- a/ui/src/pages/login-page/components/plex-login/PlexLogin.js
+++ b/ui/src/pages/login-page/components/plex-login/PlexLogin.js
@@ -76,11 +76,17 @@ class PlexLogin extends Component {
     checkRedirect() {
         const result = this.getRedirectParams();
         if (result && this.state.loggedInStatus !== 'blocked') {
-            window.requestIdleCallback(() => {
-                window.location = result.redirectPath;
-            }, {
-                timeout: 1000
-            });
+            if ('requestIdleCallback' in window) {
+                requestIdleCallback(() => {
+                    window.location = result.redirectPath;
+                }, {
+                    timeout: 1000
+                });
+            } else {
+                setTimeout(() => {
+                    window.location = result.redirectPath;
+                  }, 1000);
+            }
             return result.redirectPath;
         }
         return null;


### PR DESCRIPTION
Safari on Mac and iOS do not support requestIdleCallback. This results in redirects not working on those platforms.

If requestIdleCallback is not available this falls back on setTimeout so Apple users can leverage PlexSSO more smoothly

This should resolve https://github.com/drkno/PlexSSOv2/issues/44